### PR TITLE
fix warning

### DIFF
--- a/src/graphqlAdonis.ts
+++ b/src/graphqlAdonis.ts
@@ -29,7 +29,7 @@ export async function graphqlAdonis(ctx: HttpContextContract, options: GraphQLOp
             ...options,
             context: ctx
         },
-        query: ctx.request.method() === 'POST' ? ctx.request.post() : ctx.request.get(),
+        query: ctx.request.method() === 'POST' ? ctx.request.body() : ctx.request.get(),
         request: convertAdonisRequestToApolloRequest(ctx.request)
     }).then(({ graphqlResponse, responseInit }) => {
         if(responseInit.headers) {


### PR DESCRIPTION
Hi,

Would you mind merging this PR?

`request.post()` is deprecated in more recent versions of Express (we are using `"@adonisjs/core": "^5.1.7"`) so we are getting the following annoying warning in the logs:

```
(node:1) request.post() is deprecated. Use request.body() instead: DeprecationWarning
```

If you could merge and publish to NPM that'd be awesome and prevent us from forking it and pointing to our own fork, even if the library isn't much maintained.

Thanks!